### PR TITLE
Deepslice compatible with TensorFlow 2.19.0

### DIFF
--- a/DeepSlice/neural_network/neural_network.py
+++ b/DeepSlice/neural_network/neural_network.py
@@ -93,7 +93,11 @@ def load_xception_weights(model, weights, species="mouse"):
                 # Get name of weights in the layer
                 layer_weight_names = []
                 for weight in model.layers[xception_idx].layers[i].weights:
-                    layer_weight_names.append(weight.name.split("/")[1])
+                    try:
+                        layer_weight_names.append(weight.name.split("/")[1])
+                    except:
+                        layer_weight_names.append(f"{weight.name}:0")
+
                 h5_group = new["xception"][name_of_layer]
                 weights_list = [np.array(h5_group[kk]) for kk in layer_weight_names]
                 model.layers[xception_idx].layers[i].set_weights(weights_list)


### PR DESCRIPTION
I was trying to integrate DeepSlice into a python project I was working on in the lab; however, I found that it was not compatible with the most recent version of Tensorflow. I found that changing a few lines in the way that the model weights are read can make it compatible for both versions. Please view the changes and edit to your liking. I would greatly appreciate if this could be integrated into the python package.

Best regards! 